### PR TITLE
Add a dockerfile + a build GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: build
+
+on:
+  push:
+    branches: main
+  pull_request:
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          # Get everything so chartpress knows how to properly tag this
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          # We only install dev-requirements here, as actual requirements
+          # are built from inside a docker environment
+          cache-dependency-path: dev-requirements.txt
+          cache: 'pip'
+
+      - name: Build image with Dockerfile & repo2docker
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          NO_PUSH: true
+          IMAGE_NAME: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,5 +15,10 @@ jobs:
       - name: Build image with Dockerfile & repo2docker
         uses: jupyterhub/repo2docker-action@master
         with:
-          NO_PUSH: true
-          IMAGE_NAME: test
+          # Don't push the image during a PR build
+          NO_PUSH: "${{ github.event_name == 'pull_request' }}"
+          # Provide the username and password. These are empty when we are in a PR
+          DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          DOCKER_REGISTRY: "quay.io"
+          IMAGE_NAME: quay.io/2i2c/cellmap-segmentation-challenge-evaluator

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  login:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,22 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Checkout repo
         uses: actions/checkout@v2
-        with:
-          # Get everything so chartpress knows how to properly tag this
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          # We only install dev-requirements here, as actual requirements
-          # are built from inside a docker environment
-          cache-dependency-path: dev-requirements.txt
-          cache: 'pip'
 
       - name: Build image with Dockerfile & repo2docker
         uses: jupyterhub/repo2docker-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11
+
+COPY . /opt/repo
+
+RUN pip install --no-cache /opt/repo


### PR DESCRIPTION
- Use repo2docker-action (https://github.com/jupyterhub/repo2docker-action) for familiar (to 2i2c) tagging behavior
- Use python images as base, rather than micromamba because I could not get the micromamba image to work.
- Push to quay.io, now that the repo is public (rather than a private GCP Artifact Registry)

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/107