### PR TITLE
Use os.path.join instead of '/' when using two strings

### DIFF
--- a/src/cellmap_segmentation_challenge/evaluate.py
+++ b/src/cellmap_segmentation_challenge/evaluate.py
@@ -684,7 +684,7 @@ def score_submission(
     scores.update(
         {
             volume: missing_volume_score(
-                truth_path / volume, instance_classes=instance_classes
+                os.path.join(truth_path, volume), instance_classes=instance_classes
             )
             for volume in missing_volumes
         }


### PR DESCRIPTION
Without this, evaluations with the zip file I have fail with:

```
Scoring /input...
Unzipped /input to /input.zarr
Scoring volumes in /input.zarr...
Volumes: ['crop234']
Truth path: /opt/gt.zarr
Truth volumes: ['crop234', 'test']
Scoring volumes: ['crop234']
Missing volumes: ['test']
Scoring missing volumes as 0's
Scoring /input.zarr/crop234...
Scoring /input.zarr/crop234/er...
Scoring semantic segmentation...
IoU: 1.0000
Dice Score: 1.0000
Scoring /input.zarr/crop234/nuc...
Scoring instance segmentation...

Computing cost matrix:   0%|          | 0/1 [00:00<?, ?it/s]
Computing cost matrix: 100%|██████████| 1/1 [00:00<00:00, 15141.89it/s]

Relabeled matched instances: 0it [00:00, ?it/s]
Relabeled matched instances: 1it [00:00, 24966.10it/s]

Computing Hausdorff distances:   0%|          | 0/1 [00:00<?, ?it/s]
Computing Hausdorff distances: 100%|██████████| 1/1 [00:00<00:00, 26886.56it/s]
Traceback (most recent call last):
  File "/usr/local/bin/csc", line 8, in <module>
Accuracy: 1.0000
Hausdorff Distance: 0.0000
Normalized Hausdorff Distance: 1.0000
Combined Score: 1.0000
Missing labels: ['mito']
    sys.exit(run())
             ^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cellmap_segmentation_challenge/cli/evaluate.py", line 53, in evaluate_cli
    score_submission(submission_path, result_file, truth_path, instance_classes)
  File "/usr/local/lib/python3.11/site-packages/cellmap_segmentation_challenge/evaluate.py", line 685, in score_submission
    {
  File "/usr/local/lib/python3.11/site-packages/cellmap_segmentation_challenge/evaluate.py", line 687, in <dictcomp>
    truth_path / volume, instance_classes=instance_classes
    ~~~~~~~~~~~^~~~~~~~
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```