### PR TITLE
Add evaluation documentation

### DIFF
--- a/docs/source/evaluation.rst
+++ b/docs/source/evaluation.rst
@@ -35,7 +35,7 @@ Instance Segmentations
 Semantic Segmentations
 ----------------------
 
-- **All non-instance classesm are included as semantic labels**
+- **All non-instance classes are included as semantic labels**
 
 - **Scoring Components**:
   - **Intersection over Union (IoU)**: The IoU is calculated as the intersection of the predicted and ground truth segmentations divided by their union. This metric measures the overlap between the predicted and ground truth segmentations.

--- a/docs/source/evaluation.rst
+++ b/docs/source/evaluation.rst
@@ -1,0 +1,44 @@
+Evaluation
+==========
+
+This document describes how submitted data is scored in the CellMap Segmentation Challenge.
+
+Resampling
+----------
+Before scoring, the predicted volumes are resampled to ensure they are compared to the ground truth at the same resolution and region of interest (ROI). For more details on the resampling process, refer to `evaluation_resampling.rst`.
+
+Instance Segmentations
+----------------------
+
+- **Classes Included**: The following classes are included in the instance segmentation evaluation:
+  - Cell (`cell`)
+  - Endosome (`endo`)
+  - Lipid droplet (`ld`)
+  - Lysosome (`lyso`)
+  - Mitochondria (`mito`)
+  - Microtubule (`mt`)
+  - Nuclear pore (`np`)
+  - Nucleus (`nuc`)
+  - Peroxisome (`perox`)
+  - Vesicle (`ves`)
+  - Vimentin (`vim`)
+
+- **Scoring Components**:
+  - **Hausdorff Distance**: The Hausdorff distance is calculated in nanometers between the predicted and ground truth instance segmentations. This metric measures the maximum distance between any point on the predicted instance and its nearest point on the ground truth instance, and vice versa.
+  - **Accuracy**: The accuracy is calculated as the proportion of correctly predicted instance labels to the total number of instance labels.
+
+- **Score Normalization and Combination**:
+  - The Hausdorff distance is normalized to a range of [0, 1] using the maximum distance represented by a voxel. Specifically, the normalized Hausdorff distance is 1.01^(- hausdorff distance / ||voxel_size||)
+  - The combined score is calculated as the geometric mean of the accuracy and the normalized Hausdorff distance.
+
+Semantic Segmentations
+----------------------
+
+- **All non-instance classesm are included as semantic labels**
+
+- **Scoring Components**:
+  - **Intersection over Union (IoU)**: The IoU is calculated as the intersection of the predicted and ground truth segmentations divided by their union. This metric measures the overlap between the predicted and ground truth segmentations.
+  - **Dice Score**: The Dice score is calculated as twice the intersection of the predicted and ground truth segmentations divided by the sum of their volumes. This metric measures the similarity between the predicted and ground truth segmentations.
+
+- **Score Normalization and Combination**:
+  - The IoU scores are combined across all volumes to obtain the final scores, normalized by the volume occupied by the voxels to which each IoU corresponds.

--- a/docs/source/evaluation.rst
+++ b/docs/source/evaluation.rst
@@ -28,8 +28,9 @@ Instance Segmentations
   - **Accuracy**: The accuracy is calculated as the proportion of correctly predicted instance labels to the total number of instance labels.
 
 - **Score Normalization and Combination**:
-  - The Hausdorff distance is normalized to a range of [0, 1] using the maximum distance represented by a voxel. Specifically, the normalized Hausdorff distance is 1.01^(- hausdorff distance / ||voxel_size||)
+  - The Hausdorff distance is normalized to a range of [0, 1] using the maximum distance represented by a voxel. Specifically, the normalized Hausdorff distance is 1.01^(-hausdorff distance / ||voxel_size||)
   - The combined score is calculated as the geometric mean of the accuracy and the normalized Hausdorff distance.
+  - The final instance score across volumes is produced by taking the average across the combined scores for each volume, normalized by the total spatial volume of each image.
 
 Semantic Segmentations
 ----------------------
@@ -41,4 +42,4 @@ Semantic Segmentations
   - **Dice Score**: The Dice score is calculated as twice the intersection of the predicted and ground truth segmentations divided by the sum of their volumes. This metric measures the similarity between the predicted and ground truth segmentations.
 
 - **Score Normalization and Combination**:
-  - The IoU scores are combined across all volumes to obtain the final scores, normalized by the volume occupied by the voxels to which each IoU corresponds.
+  - The IoU scores are combined across all volumes to obtain the final scores, normalized by the total volume occupied by the volumes to which each IoU corresponds.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@
    :caption: Evaluation:
 
    evaluation_resampling.rst
+   evaluation.rst
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Fixes #66

Add `evaluation.rst` to specify how submitted data is scored in the CellMap Segmentation Challenge.

* Describe resampling and refer to `evaluation_resampling.rst`.
* Describe instance segmentations, including classes, scoring components (Hausdorff distance in nanometers and accuracy), and score normalization.
* Describe semantic segmentations, including classes, scoring components (intersection over union), and score normalization.
* Include `evaluation.rst` in the Evaluation section of `docs/source/index.rst`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/janelia-cellmap/cellmap-segmentation-challenge/pull/67?shareId=17d8f993-75b9-42c5-8f6a-e4a849c55cc4).