### PR TITLE
support having extra args for dataloader

### DIFF
--- a/src/cellmap_segmentation_challenge/utils/dataloader.py
+++ b/src/cellmap_segmentation_challenge/utils/dataloader.py
@@ -37,6 +37,7 @@ def get_dataloader(
     device: Optional[str | torch.device] = None,
     use_mutual_exclusion: bool = False,
     weighted_sampler: bool = True,
+    **kwargs: Any,
 ) -> tuple[CellMapDataLoader, CellMapDataLoader]:
     """
     Get the train and validation dataloaders.
@@ -146,6 +147,7 @@ def get_dataloader(
         batch_size=batch_size,
         is_train=random_validation,
         device=device,
+        **kwargs,
     )
 
     train_loader = CellMapDataLoader(
@@ -156,6 +158,7 @@ def get_dataloader(
             iterations_per_epoch * batch_size, weighted=weighted_sampler
         ),
         device=device,
+        **kwargs,
     )
 
     return train_loader, validation_loader  # type: ignore


### PR DESCRIPTION
support passing extra args. 
e.g. this args made it a lot faster
```python
train_loader, val_loader = get_dataloader(
                    ...
                    num_workers=num_worker,           # how many subprocesses load data
                    prefetch_factor=prefetch,       # number of batches prefetched per worker
                    pin_memory=pin_mem,         # speed up host to device transfer if using GPUs
                    persistent_workers=persistance  # avoids worker shutdown after each epoch
                )
```
![time_3](https://github.com/user-attachments/assets/43c18b07-f7d7-40a4-9ebd-bee022c91751)