### PR TITLE
Datasplit filtering by scale

### DIFF
--- a/src/cellmap_segmentation_challenge/cli/datasplit.py
+++ b/src/cellmap_segmentation_challenge/cli/datasplit.py
@@ -16,6 +16,13 @@ from cellmap_segmentation_challenge.utils.datasplit import (
     help="A comma-separated list of classes to include in the csv. Defaults to nuc,er.",
 )
 @click.option(
+    "--scale",
+    "-s",
+    nargs=3,
+    default=(64.0, 64.0, 64.0),
+    help="Filter out crops that don't have data at required scale. Example: -s 1.0 2.0 3.0",
+)
+@click.option(
     "--force-all-classes",
     "-fa",
     is_flag=True,
@@ -76,6 +83,7 @@ from cellmap_segmentation_challenge.utils.datasplit import (
 )
 def make_datasplit_csv_cli(
     classes,
+    scale,
     force_all_classes,
     force_all_classes_train,
     force_all_classes_validate,
@@ -111,6 +119,7 @@ def make_datasplit_csv_cli(
 
         make_datasplit_csv(
             classes=classes,
+            scale=scale,
             force_all_classes=force_all_classes,
             validation_prob=validate_ratio,
             search_path=search_path,

--- a/src/cellmap_segmentation_challenge/config.py
+++ b/src/cellmap_segmentation_challenge/config.py
@@ -24,6 +24,6 @@ TRUTH_PATH = (BASE_DATA_PATH / "ground_truth.zarr").path
 # GT_S3_BUCKET = "janelia-cellmap-fg5f2y1pl8"
 GT_S3_BUCKET = "janelia-cosem-datasets"
 RAW_S3_BUCKET = "janelia-cosem-datasets"
-S3_SEARCH_PATH = "{dataset}/{dataset}.zarr/recon-1/{name}"
+S3_SEARCH_PATH = "{dataset}/{dataset}.zarr/recon-1/labels/{name}"
 S3_CROP_NAME = "groundtruth/{crop}/{label}"
 S3_RAW_NAME = "em/fibsem-uint8"


### PR DESCRIPTION
When running data_loader for a list of classes over datatasplit.csv, empty data was returned for some samples. This happens when requested scale in the dataloader is lower than the annotated resolution for ground truth, and only matching resolution scale fibsem-data is downloaded. To avoid loading empty data, the filtering by scale was added into `make_datasplit_csv()` method.
`csc make-datasplit -c mito,nuc -s 6.0 6.0 6.0` - to generate datasplit.csv with a list of crops that have em data at specific `scale = [6.0, 6.0, 6.0]`