### PR TITLE
Minor fix to avoid downloading all resolutions

### DIFF
--- a/src/cellmap_segmentation_challenge/cli/fetch_data.py
+++ b/src/cellmap_segmentation_challenge/cli/fetch_data.py
@@ -323,8 +323,11 @@ def fetch_data_cli(
                     _, (current_scale, _) = transforms_from_coords(
                         array.coords, transform_precision=4
                     )
+
+                    # Scale ratio of ground truth resolution compared to the current source resolution.
+                    # i.e. 1 is the desired (highest) resolution input, and all ratio values <1 are not desired.
                     scale_ratios = tuple(
-                        s_current / s_gt
+                        s_gt / s_current
                         for s_current, s_gt in zip(
                             current_scale.scale, base_gt_scale.scale
                         )


### PR DESCRIPTION
Hi team,

I will connect the PR with my questions and some feedback on your repository (awesome repo organization btw!) via an issue!

For now, this PR takes care of a minor fix to match the expected `ratio_threshold` factor decided by `fetch_all_em_resolutions` argument. Previously, it fetched all resolution regardless of the flag. With this PR, it works as expected (i.e. gets only the highest resolution input volume)!

GTG from my side! 

