### PR TITLE
fix: budget autoscaler against cgroup memory limit, not host RAM

### DIFF
--- a/src/cellmap_segmentation_challenge/utils/eval_utils/submission.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/submission.py
@@ -350,7 +350,7 @@ def _execute_parallel_scoring(
     effective_workers = config.max_workers
     effective_threads = config.per_instance_threads
     min_per_instance_threads = 4
-    safety_factor = 1.5
+    safety_factor = 1.0  # no extra safety margin; the peak estimate is already worst-case
     peak_gb = 0.0
 
     try:

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/submission.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/submission.py
@@ -357,7 +357,19 @@ def _execute_parallel_scoring(
         import psutil
 
         vm = psutil.virtual_memory()
-        total_gb = vm.total / (1024**3)
+        # Budget against the cgroup/container memory limit when one is set,
+        # not the host's RAM -- otherwise we over-commit and OOM. Use whichever
+        # is smaller; fall back to host RAM when there's no limit.
+        total_bytes = vm.total
+        for _p in ("/sys/fs/cgroup/memory.max",                     # cgroup v2
+                   "/sys/fs/cgroup/memory/memory.limit_in_bytes"):  # cgroup v1
+            try:
+                with open(_p) as _f:
+                    total_bytes = min(total_bytes, int(_f.read()))
+                break
+            except (OSError, ValueError):  # missing file, or "max" (unlimited)
+                continue
+        total_gb = total_bytes / (1024**3)
         reserve_gb = max(16.0, 0.05 * total_gb)
         budget_gb = max(total_gb - reserve_gb, 1.0)
 


### PR DESCRIPTION
The autoscaler read psutil.virtual_memory().total (the host's RAM), so inside a container it over-budgeted against the whole machine instead of the container limit and could OOM. Read the cgroup limit (v2 memory.max / v1 memory.limit_in_bytes) and use the smaller of it and host RAM, falling back to host RAM when no limit is set.