### PR TITLE
score empty-vs-empty instance class as 1.0 (avoid 0/0 true negative)

### DIFF
--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -233,7 +233,11 @@ def score_instance(
     tp = len(matched_gt_ids)
     fp = n_pred - len(matched_pred_ids)
     fn = len(gt_ids) - len(matched_gt_ids)
-    f1 = (2 * tp / (2 * tp + fp + fn)) if (2 * tp + fp + fn) > 0 else 0.0
+    if len(gt_ids) == 0 and n_pred == 0:
+        # Correct true negative - 0/0, should be scored as 1.0
+        f1 = 1.0
+    else:
+        f1 = (2 * tp / (2 * tp + fp + fn)) if (2 * tp + fp + fn) > 0 else 0.0
 
     # Aggregate scores
     logging.info("Computing final scores...")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import os
+import matplotlib
 
 # Use the non-interactive Agg backend so that tests importing matplotlib.pyplot
 # work on headless/Windows CI runners where Tkinter/Tcl-Tk is unavailable.
-os.environ.setdefault("MPLBACKEND", "Agg")
+matplotlib.use("Agg")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# Use the non-interactive Agg backend so that tests importing matplotlib.pyplot
+# work on headless/Windows CI runners where Tkinter/Tcl-Tk is unavailable.
+os.environ.setdefault("MPLBACKEND", "Agg")

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -465,6 +465,23 @@ def test_score_instance_f1_all_fn():
     assert scores["fn"] == 2
 
 
+def test_score_instance_empty_vs_empty_true_negative():
+    """Neither GT nor prediction has instances -> correct true negative, score 1.0."""
+    from cellmap_segmentation_challenge import evaluate as ev
+
+    truth = np.zeros((4, 4), dtype=np.int32)
+    pred = np.zeros((4, 4), dtype=np.int32)
+    scores = ev.score_instance(pred, truth, voxel_size=(1.0, 1.0))
+
+    assert scores["tp"] == 0
+    assert scores["fp"] == 0
+    assert scores["fn"] == 0
+    # Correctly predicting absence is perfect, 0/0 -> 1.0
+    assert np.isclose(scores["f1"], 1.0)
+    assert np.isclose(scores["normalized_hausdorff_distance"], 1.0)
+    assert np.isclose(scores["combined_score"], 1.0)
+
+
 def test_score_instance_f1_partial_match():
     """GT has 3 instances, prediction matches 2 of them + has 1 extra -> partial F1."""
     from cellmap_segmentation_challenge import evaluate as ev


### PR DESCRIPTION

When an instance class is annotated "not present" (empty ground-truth array) and
the submission also predicts nothing, the F1 formula computes `0/0` and falls back
to `0.0` — penalizing a correct true negative. 

## Fix
Guard the `0/0` case in `score_instance`:

```python
if len(gt_ids) == 0 and n_pred == 0:
    f1 = 1.0
else:
    f1 = (2 * tp / (2 * tp + fp + fn)) if (2 * tp + fp + fn) > 0 else 0.0
