### PR TITLE
Jaccard aggregated

### DIFF
--- a/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
@@ -35,13 +35,14 @@ def combine_scores(
         combined_scores = combine_scores(scores)
     """
 
-    # Combine label scores across volumes, normalizing by the number of voxels
+    # Combine label scores across volumes. Both regimes pool raw TP/FP/FN per
+    # class (instance F1 and semantic IoU); instance also voxel-weights its
+    # continuous metrics (hausdorff / combined_score).
     logging.info(f"Combining label scores...")
     scores = scores.copy()
     label_scores = {}
     total_voxels = {}
-    # Track instance F1 counts separately (sum TP/FP/FN, then compute F1)
-    instance_counts = {}  # label -> {"tp": int, "fp": int, "fn": int}
+    counts = {}  # label -> {"tp": int, "fp": int, "fn": int}
     for ds, these_scores in scores.items():
         # Skip aggregation-level keys that are not per-crop result dicts
         if not isinstance(these_scores, dict):
@@ -59,49 +60,42 @@ def combine_scores(
         for label, this_score in these_scores.items():
             if this_score["is_missing"] and not include_missing:
                 continue
-            if label in instance_classes:
-                if label not in label_scores:
-                    label_scores[label] = {
+            if label not in label_scores:
+                label_scores[label] = (
+                    {
                         "hausdorff_distance": 0,
                         "normalized_hausdorff_distance": 0,
                         "combined_score": 0,
                     }
-                    instance_counts[label] = {"tp": 0, "fp": 0, "fn": 0}
-                    total_voxels[label] = 0
-                # Accumulate TP/FP/FN counts directly (not voxel-weighted)
-                for count_key in ("tp", "fp", "fn"):
-                    if count_key in this_score:
-                        instance_counts[label][count_key] += this_score[count_key]
-            else:
-                if label not in label_scores:
-                    label_scores[label] = {"iou": 0, "dice_score": 0}
-                    total_voxels[label] = 0
+                    if label in instance_classes
+                    else {}
+                )
+                counts[label] = {"tp": 0, "fp": 0, "fn": 0}
+                total_voxels[label] = 0
+            for count_key in ("tp", "fp", "fn"):
+                if count_key in this_score and this_score[count_key] is not None:
+                    counts[label][count_key] += this_score[count_key]
             for key in label_scores[label].keys():
                 if this_score[key] is None:
                     continue
                 label_scores[label][key] += this_score[key] * this_score["num_voxels"]
-                if this_score[key] in cast_to_none:
-                    scores[ds][label][key] = None
             total_voxels[label] += this_score["num_voxels"]
 
-    # Normalize back to the total number of voxels
+    # Normalize per class; compute the pooled ratio (instance F1, semantic IoU).
     for label in label_scores:
+        tp, fp, fn = counts[label]["tp"], counts[label]["fp"], counts[label]["fn"]
         if label in instance_classes:
             label_scores[label]["hausdorff_distance"] /= total_voxels[label]
             label_scores[label]["normalized_hausdorff_distance"] /= total_voxels[label]
             label_scores[label]["combined_score"] /= total_voxels[label]
-            # Compute F1 from aggregated counts
-            counts = instance_counts[label]
-            tp, fp, fn = counts["tp"], counts["fp"], counts["fn"]
             denom = 2 * tp + fp + fn
             label_scores[label]["f1"] = (2 * tp / denom) if denom > 0 else 0.0
-            label_scores[label]["tp"] = tp
-            label_scores[label]["fp"] = fp
-            label_scores[label]["fn"] = fn
         else:
-            label_scores[label]["iou"] /= total_voxels[label]
-            label_scores[label]["dice_score"] /= total_voxels[label]
-        # Cast to None if the value is in `cast_to_none`
+            denom = tp + fp + fn
+            label_scores[label]["iou"] = (tp / denom) if denom > 0 else 1.0
+        label_scores[label]["tp"] = tp
+        label_scores[label]["fp"] = fp
+        label_scores[label]["fn"] = fn
         for key in label_scores[label]:
             if label_scores[label][key] in cast_to_none:
                 label_scores[label][key] = None

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
@@ -108,25 +108,20 @@ def combine_scores(
     instance_total_voxels = sum(
         total_voxels[label] for label in label_scores if label in instance_classes
     )
-    semantic_total_voxels = sum(
-        total_voxels[label] for label in label_scores if label not in instance_classes
-    )
     for label in label_scores:
         if label in instance_classes:
             overall_instance_scores += [
                 label_scores[label]["combined_score"] * total_voxels[label]
             ]
         else:
-            overall_semantic_scores += [
-                label_scores[label]["iou"] * total_voxels[label]
-            ]
+            overall_semantic_scores += [label_scores[label]["iou"]]  # plain mean
     scores["overall_instance_score"] = (
         np.nansum(overall_instance_scores) / instance_total_voxels
         if overall_instance_scores
         else 0
     )
     scores["overall_semantic_score"] = (
-        np.nansum(overall_semantic_scores) / semantic_total_voxels
+        np.nansum(overall_semantic_scores) / len(overall_semantic_scores)
         if overall_semantic_scores
         else 0
     )

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
@@ -81,18 +81,29 @@ def combine_scores(
                 label_scores[label][key] += this_score[key] * this_score["num_voxels"]
             total_voxels[label] += this_score["num_voxels"]
 
-    # Normalize per class; compute the pooled ratio (instance F1, semantic IoU).
+    # Normalize per class; accumulate the overall (instance voxel-weighted,
+    # semantic plain per-class mean).
+    instance_weighted_sum = 0.0
+    instance_total_voxels = 0
+    semantic_score_sum = 0.0
+    semantic_class_count = 0
     for label in label_scores:
         tp, fp, fn = counts[label]["tp"], counts[label]["fp"], counts[label]["fn"]
         if label in instance_classes:
+            combined_sum = label_scores[label]["combined_score"]  # pre-division sum
             label_scores[label]["hausdorff_distance"] /= total_voxels[label]
             label_scores[label]["normalized_hausdorff_distance"] /= total_voxels[label]
-            label_scores[label]["combined_score"] /= total_voxels[label]
+            label_scores[label]["combined_score"] = combined_sum / total_voxels[label]
             denom = 2 * tp + fp + fn
             label_scores[label]["f1"] = (2 * tp / denom) if denom > 0 else 0.0
+            instance_weighted_sum += combined_sum
+            instance_total_voxels += total_voxels[label]
         else:
             denom = tp + fp + fn
-            label_scores[label]["iou"] = (tp / denom) if denom > 0 else 1.0
+            iou = (tp / denom) if denom > 0 else 1.0  # denom 0 = nothing anywhere
+            label_scores[label]["iou"] = iou
+            semantic_score_sum += iou  # plain per-class mean
+            semantic_class_count += 1
         label_scores[label]["tp"] = tp
         label_scores[label]["fp"] = fp
         label_scores[label]["fn"] = fn
@@ -101,29 +112,12 @@ def combine_scores(
                 label_scores[label][key] = None
     scores["label_scores"] = label_scores
 
-    # Compute the overall score
     logging.info("Computing overall scores...")
-    overall_instance_scores = []
-    overall_semantic_scores = []
-    instance_total_voxels = sum(
-        total_voxels[label] for label in label_scores if label in instance_classes
-    )
-    for label in label_scores:
-        if label in instance_classes:
-            overall_instance_scores += [
-                label_scores[label]["combined_score"] * total_voxels[label]
-            ]
-        else:
-            overall_semantic_scores += [label_scores[label]["iou"]]  # plain mean
     scores["overall_instance_score"] = (
-        np.nansum(overall_instance_scores) / instance_total_voxels
-        if overall_instance_scores
-        else 0
+        instance_weighted_sum / instance_total_voxels if instance_total_voxels else 0
     )
     scores["overall_semantic_score"] = (
-        np.nansum(overall_semantic_scores) / len(overall_semantic_scores)
-        if overall_semantic_scores
-        else 0
+        semantic_score_sum / semantic_class_count if semantic_class_count else 0
     )
     scores["overall_score"] = (
         scores["overall_instance_score"] * scores["overall_semantic_score"]

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/distance.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/distance.py
@@ -38,6 +38,7 @@ def optimized_hausdorff_distances(
     hausdorff_distance_max,
     method="standard",
     percentile: float | None = None,
+    truth_ids=None,
 ):
     """
     Compute per-truth-instance Hausdorff-like distances against the (already remapped)
@@ -63,9 +64,10 @@ def optimized_hausdorff_distances(
     percentile : float | None
         Percentile (0-100) used when method=="percentile".
     """
-    # Unique GT ids (exclude background = 0)
-    truth_ids = unique(truth_label)
-    truth_ids = truth_ids[truth_ids != 0]
+    # Unique GT ids (exclude background = 0); reuse caller's if provided.
+    if truth_ids is None:
+        truth_ids = unique(truth_label)
+        truth_ids = truth_ids[truth_ids != 0]
     true_num = int(truth_ids.size)
     if true_num == 0:
         return np.empty((0,), dtype=np.float32)

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -64,6 +64,7 @@ def _compute_hausdorff_scores(
     n_pred: int,
     voxel_size: tuple[float, ...],
     hausdorff_distance_max: float,
+    truth_ids: np.ndarray | None = None,
 ) -> list[float]:
     """Compute Hausdorff distances for matched instances.
 
@@ -74,6 +75,7 @@ def _compute_hausdorff_scores(
         n_pred: Number of predicted instances
         voxel_size: Voxel size
         hausdorff_distance_max: Maximum distance
+        truth_ids: Precomputed non-zero ground-truth ids
 
     Returns:
         List of Hausdorff distances
@@ -85,7 +87,7 @@ def _compute_hausdorff_scores(
     if len(mapping) > 0:
         # Compute Hausdorff for matched instances
         hausdorff_distances = optimized_hausdorff_distances(
-            truth_label, pred_label, voxel_size, hausdorff_distance_max
+            truth_label, pred_label, voxel_size, hausdorff_distance_max, truth_ids=truth_ids
         )
 
         # Add max distance for unmatched predictions

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -237,7 +237,7 @@ def score_instance(
         # Correct true negative - 0/0, should be scored as 1.0
         f1 = 1.0
     else:
-        f1 = (2 * tp / (2 * tp + fp + fn)) if (2 * tp + fp + fn) > 0 else 0.0
+        f1 = 2 * tp / (2 * tp + fp + fn)
 
     # Aggregate scores
     logging.info("Computing final scores...")

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -29,7 +29,6 @@ from .types import InstanceScoreDict
 
 
 def _create_pathological_scores(
-    binary_metrics: dict[str, float],
     hausdorff_distance_max: float,
     voxel_size: tuple[float, ...],
     status: str,
@@ -37,7 +36,6 @@ def _create_pathological_scores(
     """Create scores for pathological cases (matching failed).
 
     Args:
-        binary_metrics: Pre-computed binary metrics
         hausdorff_distance_max: Maximum Hausdorff distance
         voxel_size: Voxel size
         status: Status string for the failure
@@ -50,14 +48,11 @@ def _create_pathological_scores(
         "tp": 0,
         "fp": 0,
         "fn": 0,
-        "binary_accuracy": binary_metrics["binary_accuracy"],
         "hausdorff_distance": hausdorff_distance_max,
         "normalized_hausdorff_distance": normalize_distance(
             hausdorff_distance_max, voxel_size
         ),
         "combined_score": 0,
-        "iou": binary_metrics["iou"],
-        "dice_score": binary_metrics["dice_score"],
         "status": status,
     }
 

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -231,7 +231,7 @@ def score_instance(
     }
 
 
-def score_semantic(pred_label, truth_label) -> dict[str, float]:
+def score_semantic(pred_label, truth_label) -> dict[str, int | str]:
     """
     Score a single semantic label volume against the ground truth semantic label volume.
 
@@ -250,26 +250,19 @@ def score_semantic(pred_label, truth_label) -> dict[str, float]:
     pred_label = (pred_label > 0.0).ravel()
     truth_label = (truth_label > 0.0).ravel()
 
-    # Compute the scores
-    if np.sum(truth_label + pred_label) == 0:
-        # If there are no true or false positives, set the scores to 1
-        logging.debug("No true or false positives found. Setting scores to 1.")
-        dice_score = 1
-        iou_score = 1
-    else:
-        dice_score = 1 - dice(truth_label, pred_label)
-        iou_score = jaccard_score(truth_label, pred_label, zero_division=1)
-    scores = {
-        "iou": iou_score,
-        "dice_score": dice_score if not np.isnan(dice_score) else 1,
-        "binary_accuracy": float((truth_label == pred_label).mean()),
+    # Voxel confusion counts; pooled per class in aggregation to compute IoU.
+    tp = int(np.count_nonzero(truth_label & pred_label))
+    fp = int(pred_label.sum()) - tp
+    fn = int(truth_label.sum()) - tp
+
+    logging.info(f"Semantic counts: TP={tp}, FP={fp}, FN={fn}")
+
+    return {
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
         "status": "scored",
     }
-
-    logging.info(f"IoU: {scores['iou']:.4f}")
-    logging.info(f"Dice Score: {scores['dice_score']:.4f}")
-
-    return scores
 
 
 def score_label(

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -7,9 +7,7 @@ from time import time
 import cc3d
 import numpy as np
 import zarr
-from fastremap import remap
-from scipy.spatial.distance import dice
-from sklearn.metrics import jaccard_score
+from fastremap import remap, unique
 from upath import UPath
 
 from ...config import TRUTH_PATH, INSTANCE_CLASSES

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -28,32 +28,6 @@ from .instance_matching import match_instances
 from .types import InstanceScoreDict
 
 
-def _compute_binary_metrics(
-    truth_label: np.ndarray, pred_label: np.ndarray
-) -> dict[str, float]:
-    """Compute binary segmentation metrics.
-
-    Args:
-        truth_label: Ground truth labels
-        pred_label: Predicted labels
-
-    Returns:
-        Dictionary with iou, dice_score, and binary_accuracy
-    """
-    truth_binary = (truth_label > 0).ravel()
-    pred_binary = (pred_label > 0).ravel()
-
-    iou = jaccard_score(truth_binary, pred_binary, zero_division=1)
-    dice_score = 1 - dice(truth_binary, pred_binary)
-    binary_accuracy = float((truth_binary == pred_binary).mean())
-
-    return {
-        "iou": iou,
-        "dice_score": dice_score,
-        "binary_accuracy": binary_accuracy,
-    }
-
-
 def _create_pathological_scores(
     binary_metrics: dict[str, float],
     hausdorff_distance_max: float,

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -154,16 +154,12 @@ def score_instance(
     # TODO: Switch to just renumbering to contiguous IDs, and leave user labels intact
     pred_label, n_pred = cc3d.connected_components(pred_label, return_N=True)
 
-    # Compute metrics that don't require matching
-    binary_metrics = _compute_binary_metrics(truth_label, pred_label)
-
     # Match instances
     try:
         mapping = match_instances(truth_label, pred_label, config)
     except (TooManyInstancesError, TooManyOverlapEdgesError) as e:
         logging.warning(f"Instance matching failed: {e}")
         return _create_pathological_scores(
-            binary_metrics,
             hausdorff_distance_max,
             voxel_size,
             "skipped_too_many_instances",
@@ -171,7 +167,7 @@ def score_instance(
     except MatchingFailedError as e:
         logging.error(f"Matching optimization failed: {e}")
         return _create_pathological_scores(
-            binary_metrics, hausdorff_distance_max, voxel_size, "matching_failed"
+            hausdorff_distance_max, voxel_size, "matching_failed"
         )
 
     # Remap predictions to match GT IDs
@@ -181,28 +177,30 @@ def score_instance(
             pred_label, mapping, in_place=True, preserve_missing_labels=True
         )
 
-    # Free matching-stage scratch (overlap matrices, cc3d temporaries) before
-    # the Hausdorff phase spins up `per_instance_threads` float64 distance
-    # transforms per worker.
+    # Non-zero ground-truth ids, computed once and shared with the Hausdorff step.
+    truth_ids = unique(truth_label)
+    truth_ids = truth_ids[truth_ids != 0]
+
+    # Free matching-stage scratch before the memory-heavy Hausdorff phase.
     gc.collect()
 
     # Compute Hausdorff distances
     hausdorff_distances = _compute_hausdorff_scores(
-        mapping, truth_label, pred_label, n_pred, voxel_size, hausdorff_distance_max
+        mapping, truth_label, pred_label, n_pred, voxel_size, hausdorff_distance_max, truth_ids
     )
 
     if len(hausdorff_distances) == 0:
         hausdorff_distances = [hausdorff_distance_max]
 
     # Compute F1 from instance matching counts
-    gt_ids = set(np.unique(truth_label)) - {0}
+    gt_count = int(truth_ids.size)
     matched_gt_ids = set(mapping.values()) - {0}
     matched_pred_ids = set(mapping.keys()) - {0}
 
     tp = len(matched_gt_ids)
     fp = n_pred - len(matched_pred_ids)
-    fn = len(gt_ids) - len(matched_gt_ids)
-    if len(gt_ids) == 0 and n_pred == 0:
+    fn = gt_count - len(matched_gt_ids)
+    if gt_count == 0 and n_pred == 0:
         # Correct true negative - 0/0, should be scored as 1.0
         f1 = 1.0
     else:
@@ -210,10 +208,11 @@ def score_instance(
 
     # Aggregate scores
     logging.info("Computing final scores...")
-    hausdorff_dist = float(np.mean(hausdorff_distances))
-    normalized_hausdorff_dist = float(
-        np.mean([normalize_distance(hd, voxel_size) for hd in hausdorff_distances])
-    )
+    hausdorff_distances = np.asarray(hausdorff_distances, dtype=np.float64)
+    hausdorff_dist = float(hausdorff_distances.mean())
+    # Normalize vectorized: norm(voxel_size) is constant; inf distance -> 0.
+    vs_norm = np.linalg.norm(voxel_size)
+    normalized_hausdorff_dist = float((1.01 ** (-hausdorff_distances / vs_norm)).mean())
     combined_score = (f1 * normalized_hausdorff_dist) ** 0.5
     logging.info(f"F1: {f1:.4f} (TP={tp}, FP={fp}, FN={fn})")
     logging.info(f"Hausdorff Distance: {hausdorff_dist:.4f}")
@@ -229,7 +228,6 @@ def score_instance(
         "normalized_hausdorff_distance": normalized_hausdorff_dist,
         "combined_score": combined_score,
         "status": "scored",
-        **binary_metrics,
     }
 
 

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -351,12 +351,14 @@ def empty_label_score(
     ds = zarr.open((truth_path / crop_name / label).path, mode="r")
     voxel_size = ds.attrs["voxel_size"]
     if label in instance_classes:
-        truth_path = UPath(truth_path)
+        # Penalize non-submission: every ground-truth instance is a false negative.
+        truth_ids = unique(ds[:])
+        n_instances = int(truth_ids[truth_ids != 0].size)
         return {
             "f1": 0.0,
             "tp": 0,
             "fp": 0,
-            "fn": 0,
+            "fn": n_instances,
             "hausdorff_distance": compute_max_distance(voxel_size, ds.shape),
             "normalized_hausdorff_distance": 0,
             "combined_score": 0,
@@ -366,11 +368,13 @@ def empty_label_score(
             "status": "missing",
         }
     else:
+        # Not submitted: count every voxel as a false negative -> IoU 0.
+        n_voxels = int(np.prod(ds.shape))
         return {
-            "iou": 0,
-            "dice_score": 0,
-            "binary_accuracy": 0,
-            "num_voxels": int(np.prod(ds.shape)),
+            "tp": 0,
+            "fp": 0,
+            "fn": n_voxels,
+            "num_voxels": n_voxels,
             "voxel_size": voxel_size,
             "is_missing": True,
             "status": "missing",

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/submission.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/submission.py
@@ -527,11 +527,12 @@ def score_submission(
                 "label_name": {
                     # Instance segmentation
                     "f1": float,
+                    "tp": int, "fp": int, "fn": int,
                     "hausdorff_distance": float,
                     "combined_score": float,
-                    # OR semantic segmentation
-                    "iou": float,
-                    "dice_score": float,
+                    # OR semantic segmentation (raw voxel counts; IoU is
+                    # pooled from these per class in label_scores)
+                    "tp": int, "fp": int, "fn": int,
                 }
             },
             "label_scores": {  # Aggregated per-label

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/types.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/types.py
@@ -10,12 +10,9 @@ class InstanceScoreDict(TypedDict, total=False):
     tp: int
     fp: int
     fn: int
-    binary_accuracy: float
     hausdorff_distance: float
     normalized_hausdorff_distance: float
     combined_score: float
-    iou: float
-    dice_score: float
     num_voxels: int
     voxel_size: tuple[float, ...]
     is_missing: bool

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/types.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/types.py
@@ -24,9 +24,9 @@ class InstanceScoreDict(TypedDict, total=False):
 class SemanticScoreDict(TypedDict, total=False):
     """Type definition for semantic segmentation scores."""
 
-    iou: float
-    dice_score: float
-    binary_accuracy: float
+    tp: int
+    fp: int
+    fn: int
     num_voxels: int
     voxel_size: tuple[float, ...]
     is_missing: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+# Force non-interactive matplotlib backend (Windows CI Tk is unusable).
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import matplotlib
+
+matplotlib.use("Agg")

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -753,8 +753,10 @@ def test_combine_scores_instance_and_semantic():
         },
         "crop2": {
             "sem": {
-                "iou": 0.5,
-                "dice_score": 2 / 3,
+                # pooled IoU = TP / (TP + FP + FN) = 4 / (4 + 2 + 2) = 0.5
+                "tp": 4,
+                "fp": 2,
+                "fn": 2,
                 "num_voxels": 8,
                 "voxel_size": (1.0, 1.0, 1.0),
                 "is_missing": False,

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -724,7 +724,10 @@ def test_missing_volume_score_mixed_labels(tmp_path):
     assert scores["instance"]["is_missing"] is True
     assert scores["sem"]["is_missing"] is True
     assert scores["instance"]["f1"] == 0.0
-    assert scores["sem"]["iou"] == 0.0
+    # missing semantic is penalized: empty truth -> fp=0, fn=all voxels -> IoU 0
+    assert scores["sem"]["fp"] == 0
+    assert scores["sem"]["fn"] == arr_sem.size
+    assert "iou" not in scores["sem"]
 
 
 # ------------------------

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -530,8 +530,10 @@ def test_score_semantic_perfect_match():
     truth = np.array([[0, 1], [1, 1]], dtype=float)
     pred = truth.copy()
     scores = ev.score_semantic(pred, truth)
-    assert np.isclose(scores["iou"], 1.0)
-    assert np.isclose(scores["dice_score"], 1.0)
+    # 3 foreground voxels, all matched
+    assert scores["tp"] == 3
+    assert scores["fp"] == 0
+    assert scores["fn"] == 0
 
 
 def test_score_semantic_partial_overlap():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -545,10 +545,10 @@ def test_score_semantic_partial_overlap():
 
     scores = ev.score_semantic(pred, truth)
 
-    # manual IoU: TP = 2, FP = 0, FN = 1 -> IoU = 2 / (2+0+1) = 2/3
-    assert np.isclose(scores["iou"], 2 / 3)
-    # manual Dice: 2TP / (2TP + FP + FN) = 4 / (4 + 0 + 1) = 0.8
-    assert np.isclose(scores["dice_score"], 0.8)
+    # TP = 2, FP = 0, FN = 1 (pooled IoU = 2/3 is computed in aggregation)
+    assert scores["tp"] == 2
+    assert scores["fp"] == 0
+    assert scores["fn"] == 1
 
 
 def test_score_semantic_no_foreground():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -557,8 +557,9 @@ def test_score_semantic_no_foreground():
     truth = np.zeros((3, 3), dtype=float)
     pred = np.zeros_like(truth)
     scores = ev.score_semantic(pred, truth)
-    assert np.isclose(scores["iou"], 1.0)
-    assert np.isclose(scores["dice_score"], 1.0)
+    assert scores["tp"] == 0
+    assert scores["fp"] == 0
+    assert scores["fn"] == 0
 
 
 # ------------------------

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -40,7 +40,6 @@ from cellmap_segmentation_challenge.utils.eval_utils.instance_matching import (
 )
 from cellmap_segmentation_challenge.utils.eval_utils.scoring import (
     # Helper functions for score_instance
-    _compute_binary_metrics,
     _create_pathological_scores,
     _compute_hausdorff_scores,
 )
@@ -254,27 +253,6 @@ class TestMatchInstancesHelpers:
 
 class TestScoreInstanceHelpers:
     """Test helper functions for score_instance."""
-
-    def test_compute_binary_metrics_perfect_match(self):
-        """Test binary metrics with perfect match."""
-        truth = np.array([[1, 1], [0, 0]])
-        pred = np.array([[1, 1], [0, 0]])
-
-        metrics = _compute_binary_metrics(truth, pred)
-
-        assert metrics["iou"] == pytest.approx(1.0)
-        assert metrics["dice_score"] == pytest.approx(1.0)
-        assert metrics["binary_accuracy"] == pytest.approx(1.0)
-
-    def test_compute_binary_metrics_no_overlap(self):
-        """Test binary metrics with no overlap."""
-        truth = np.array([[1, 1], [0, 0]])
-        pred = np.array([[0, 0], [1, 1]])
-
-        metrics = _compute_binary_metrics(truth, pred)
-
-        assert metrics["iou"] == 0.0
-        assert metrics["binary_accuracy"] == 0.0
 
     def test_create_pathological_scores(self):
         """Test creation of pathological scores."""

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -256,10 +256,7 @@ class TestScoreInstanceHelpers:
 
     def test_create_pathological_scores(self):
         """Test creation of pathological scores."""
-        binary_metrics = {"iou": 0.5, "dice_score": 0.6, "binary_accuracy": 0.7}
-
         scores = _create_pathological_scores(
-            binary_metrics,
             hausdorff_distance_max=100.0,
             voxel_size=(4.0, 4.0, 4.0),
             status="test_failure",
@@ -268,7 +265,6 @@ class TestScoreInstanceHelpers:
         assert scores["f1"] == 0.0
         assert scores["combined_score"] == 0
         assert scores["hausdorff_distance"] == 100.0
-        assert scores["iou"] == 0.5
         assert scores["status"] == "test_failure"
 
     def test_compute_hausdorff_scores_only_background(self):


### PR DESCRIPTION
## Summary

Reworks scoring to drop precomputed binary metrics (dice/jaccard/accuracy) in
favor of raw `tp`/`fp`/`fn` counts, then aggregates semantic IoU by pooling
those counts per class. 

## Changes

**Scoring**
- `score_semantic` returns raw `tp`/`fp`/`fn` instead of derived metrics
- `score_instance` shares `truth_ids`, vectorizes normalization, drops binary metrics
- Delete `_compute_binary_metrics` and its callers; drop `dice`/`jaccard_score` imports
- Penalize missing submissions, semantic - all-FN, voxelwise

**Aggregation**
- Pool semantic `tp`/`fp`/`fn` into per-class IoU
- Semantic overall is a plain per-class mean
- Single-loop aggregation (drop divide-then-multiply round-trip)

**Types**
- `SemanticScoreDict` uses `tp`/`fp`/`fn`
- `InstanceScoreDict` drops `iou`/`dice`/`binary_accuracy`

**Tests / docs**
- Tests updated to assert `tp`/`fp`/`fn` across semantic + combine paths
- Result-structure docstring updated to counts
- Force Agg matplotlib backend so tests pass on Windows CI

## Notes

Base for stacked for PR #211 `F1 class aggregated`, which builds the per-class
F1/Hausdorff aggregation on top of this.
