### PR TITLE
F1/Hausdorff class aggregated

### DIFF
--- a/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
@@ -35,14 +35,13 @@ def combine_scores(
         combined_scores = combine_scores(scores)
     """
 
-    # Combine label scores across volumes. Both regimes pool raw TP/FP/FN per
-    # class (instance F1 and semantic IoU); instance also voxel-weights its
-    # continuous metrics (hausdorff / combined_score).
+    # Pool raw counts per class: tp/fp/fn (F1 / IoU) and, for instance classes,
+    # the per-instance Hausdorff sum/count (combined = sqrt(F1 * mean Hausdorff)).
     logging.info(f"Combining label scores...")
     scores = scores.copy()
     label_scores = {}
-    total_voxels = {}
-    counts = {}  # label -> {"tp": int, "fp": int, "fn": int}
+    counts = {}  # label -> {"tp", "fp", "fn"}
+    haus = {}  # instance label -> {"sum": float, "count": int}
     for ds, these_scores in scores.items():
         # Skip aggregation-level keys that are not per-crop result dicts
         if not isinstance(these_scores, dict):
@@ -61,43 +60,37 @@ def combine_scores(
             if this_score["is_missing"] and not include_missing:
                 continue
             if label not in label_scores:
-                label_scores[label] = (
-                    {
-                        "hausdorff_distance": 0,
-                        "normalized_hausdorff_distance": 0,
-                        "combined_score": 0,
-                    }
-                    if label in instance_classes
-                    else {}
-                )
+                label_scores[label] = {}
                 counts[label] = {"tp": 0, "fp": 0, "fn": 0}
-                total_voxels[label] = 0
+                if label in instance_classes:
+                    haus[label] = {"sum": 0.0, "count": 0}
             for count_key in ("tp", "fp", "fn"):
-                if count_key in this_score and this_score[count_key] is not None:
-                    counts[label][count_key] += this_score[count_key]
-            for key in label_scores[label].keys():
-                if this_score[key] is None:
-                    continue
-                label_scores[label][key] += this_score[key] * this_score["num_voxels"]
-            total_voxels[label] += this_score["num_voxels"]
+                counts[label][count_key] += this_score[count_key]
+            if label in instance_classes:
+                haus[label]["sum"] += this_score["hausdorff_norm_sum"]
+                haus[label]["count"] += this_score["n_hausdorff"]
 
-    # Normalize per class; accumulate the overall (instance voxel-weighted,
-    # semantic plain per-class mean).
-    instance_weighted_sum = 0.0
-    instance_total_voxels = 0
+    # Per-class scores; both instance and semantic overall are plain per-class means.
+    instance_score_sum = 0.0
+    instance_class_count = 0
     semantic_score_sum = 0.0
     semantic_class_count = 0
     for label in label_scores:
         tp, fp, fn = counts[label]["tp"], counts[label]["fp"], counts[label]["fn"]
         if label in instance_classes:
-            combined_sum = label_scores[label]["combined_score"]  # pre-division sum
-            label_scores[label]["hausdorff_distance"] /= total_voxels[label]
-            label_scores[label]["normalized_hausdorff_distance"] /= total_voxels[label]
-            label_scores[label]["combined_score"] = combined_sum / total_voxels[label]
             denom = 2 * tp + fp + fn
-            label_scores[label]["f1"] = (2 * tp / denom) if denom > 0 else 0.0
-            instance_weighted_sum += combined_sum
-            instance_total_voxels += total_voxels[label]
+            count = haus[label]["count"]
+            if denom == 0 and count == 0:  # nothing anywhere -> "nothing here"
+                f1 = hausdorff = combined = 1.0
+            else:
+                f1 = (2 * tp / denom) if denom > 0 else 0.0
+                hausdorff = haus[label]["sum"] / count if count > 0 else 0.0
+                combined = (f1 * hausdorff) ** 0.5
+            label_scores[label]["f1"] = f1
+            label_scores[label]["normalized_hausdorff_distance"] = hausdorff
+            label_scores[label]["combined_score"] = combined
+            instance_score_sum += combined  # plain per-class mean
+            instance_class_count += 1
         else:
             denom = tp + fp + fn
             iou = (tp / denom) if denom > 0 else 1.0  # denom 0 = nothing anywhere
@@ -114,7 +107,7 @@ def combine_scores(
 
     logging.info("Computing overall scores...")
     scores["overall_instance_score"] = (
-        instance_weighted_sum / instance_total_voxels if instance_total_voxels else 0
+        instance_score_sum / instance_class_count if instance_class_count else 0
     )
     scores["overall_semantic_score"] = (
         semantic_score_sum / semantic_class_count if semantic_class_count else 0

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
@@ -226,18 +226,19 @@ def update_scores(scores, results, result_file, instance_classes=INSTANCE_CLASSE
         # Classes with at least one real submission -> shown in the public file.
         submitted_labels = set(found_scores.get("label_scores", {}))
 
-        # Full (server-side): every per-crop count. Public: aggregate-only, submitted classes.
+        # Public (participant-facing): aggregate-only, submitted classes.
         with open(result_file, "w") as f:
-            json.dump(all_scores, f, indent=4)
-
-        public_file = str(result_file).replace(
-            UPath(result_file).suffix, "_public" + UPath(result_file).suffix
-        )
-        with open(public_file, "w") as f:
             json.dump(public_scores(all_scores, submitted_labels), f, indent=4)
 
+        # Server-side (_extended): full scores with every per-crop count.
+        extended_file = str(result_file).replace(
+            UPath(result_file).suffix, "_extended" + UPath(result_file).suffix
+        )
+        with open(extended_file, "w") as f:
+            json.dump(all_scores, f, indent=4)
+
         logging.info(
-            f"Scores updated in {result_file} and {public_file} in {time() - start_time:.2f} seconds"
+            f"Scores updated in {result_file} and {extended_file} in {time() - start_time:.2f} seconds"
         )
     else:
         logging.info("Final combined scores:")

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/aggregation.py
@@ -12,6 +12,17 @@ from ..crops import TEST_CROPS_DICT
 from ..utils import get_git_hash
 from .config import CAST_TO_NONE
 
+# Aggregate-level keys in a combined-scores dict; everything else is a per-crop entry.
+AGGREGATE_KEYS = (
+    "label_scores",
+    "overall_instance_score",
+    "overall_semantic_score",
+    "overall_score",
+    "total_evals",
+    "num_evals_done",
+    "git_version",
+)
+
 
 def combine_scores(
     scores,
@@ -46,15 +57,7 @@ def combine_scores(
         # Skip aggregation-level keys that are not per-crop result dicts
         if not isinstance(these_scores, dict):
             continue
-        if ds in (
-            "label_scores",
-            "overall_instance_score",
-            "overall_semantic_score",
-            "overall_score",
-            "total_evals",
-            "num_evals_done",
-            "git_version",
-        ):
+        if ds in AGGREGATE_KEYS:
             continue
         for label, this_score in these_scores.items():
             if this_score["is_missing"] and not include_missing:
@@ -166,6 +169,29 @@ def sanitize_scores(scores):
     return scores
 
 
+def public_scores(scores, submitted_labels):
+    """Aggregate-only view for the participant-facing file.
+
+    Keeps the overall scores and the per-class ratio scores (f1/iou/combined)
+    for the submitted classes.
+
+    Args:
+        scores (dict): A combined-scores dict as returned by `combine_scores`.
+        submitted_labels (set): Class names to include in the per-class scores.
+
+    Returns:
+        dict: Overall scores and per-class ratio scores.
+    """
+    public = {k: scores[k] for k in AGGREGATE_KEYS if k in scores}
+    drop = ("tp", "fp", "fn")
+    public["label_scores"] = {
+        label: {k: v for k, v in s.items() if k not in drop}
+        for label, s in scores.get("label_scores", {}).items()
+        if label in submitted_labels
+    }
+    return public
+
+
 def update_scores(scores, results, result_file, instance_classes=INSTANCE_CLASSES):
     start_time = time()
     logging.info(f"Updating scores in {result_file}...")
@@ -196,17 +222,22 @@ def update_scores(scores, results, result_file, instance_classes=INSTANCE_CLASSE
     if result_file is not None:
         logging.info(f"Saving collected scores to {result_file}...")
 
-        with open(result_file, "w") as f:
-            json.dump(sanitize_scores(all_scores), f, indent=4)
+        sanitize_scores(all_scores)
+        # Classes with at least one real submission -> shown in the public file.
+        submitted_labels = set(found_scores.get("label_scores", {}))
 
-        found_result_file = str(result_file).replace(
-            UPath(result_file).suffix, "_submitted_only" + UPath(result_file).suffix
+        # Full (server-side): every per-crop count. Public: aggregate-only, submitted classes.
+        with open(result_file, "w") as f:
+            json.dump(all_scores, f, indent=4)
+
+        public_file = str(result_file).replace(
+            UPath(result_file).suffix, "_public" + UPath(result_file).suffix
         )
-        with open(found_result_file, "w") as f:
-            json.dump(sanitize_scores(found_scores), f, indent=4)
+        with open(public_file, "w") as f:
+            json.dump(public_scores(all_scores, submitted_labels), f, indent=4)
 
         logging.info(
-            f"Scores updated in {result_file} and {found_result_file} in {time() - start_time:.2f} seconds"
+            f"Scores updated in {result_file} and {public_file} in {time() - start_time:.2f} seconds"
         )
     else:
         logging.info("Final combined scores:")

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/distance.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/distance.py
@@ -21,14 +21,23 @@ def compute_max_distance(voxel_size, shape) -> float:
     return float(min([(v * s) / 2 for v, s in zip(voxel_size, shape)]))
 
 
-def normalize_distance(distance: float, voxel_size) -> float:
+def normalize_distance(distance, voxel_size):
+    """Normalize a distance to ``(0, 1]`` via ``1.01 ** (-distance / ||voxel_size||)``.
+
+    A distance of 0 maps to 1 (perfect) and inf maps to 0. Accepts a scalar or
+    an array, returning a float for scalar input and an array otherwise.
+
+    Args:
+        distance: Distance value(s), scalar or array.
+        voxel_size: Physical voxel size.
+
+    Returns:
+        Normalized score(s) in ``(0, 1]``.
     """
-    Normalize a distance value to [0, 1] using the maximum distance represented by a voxel
-    """
-    if distance == np.inf:
-        return 0.0
     # TODO: Normalize by max possible distance in the volume
-    return float((1.01 ** (-distance / np.linalg.norm(voxel_size))))
+    d = np.asarray(distance, dtype=np.float64)
+    out = np.where(np.isinf(d), 0.0, 1.01 ** (-d / np.linalg.norm(voxel_size)))
+    return float(out) if out.ndim == 0 else out
 
 
 def optimized_hausdorff_distances(

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/distance.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/distance.py
@@ -172,8 +172,8 @@ def roi_slices_for_pair(
         # tolerate vs longer (e.g. includes channel), take last ndim
         vs = vs[-ndim:]
 
-    # padding per axis in voxels
-    pad = np.ceil(max_distance / vs).astype(int) + 2
+    # pad per axis, clamped to volume extent
+    pad = np.minimum(np.ceil(max_distance / vs), shape).astype(int) + 2
 
     tb = bbox_for_label(truth_stats, ndim, tid)
     assert tb is not None, f"Truth ID {tid} not found in truth statistics."

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -308,21 +308,35 @@ def score_label(
 def empty_label_score(
     label, crop_name, instance_classes=INSTANCE_CLASSES, truth_path=TRUTH_PATH
 ):
+    """Score a not-submitted label as a penalized "missing" volume.
+
+    Non-submission is penalized harder than a (submitted) empty prediction:
+    instance classes count every ground-truth instance as a false negative at a
+    worst-case (zero) boundary score; semantic classes count every voxel as a
+    false negative. Used when a label is absent from the submission.
+
+    Args:
+        label: Label/class name.
+        crop_name: Crop identifier.
+        instance_classes: Names of instance-segmented classes.
+        truth_path: Path to the ground-truth zarr.
+
+    Returns:
+        A per-volume score dict flagged ``is_missing=True``.
+    """
     truth_path = UPath(truth_path)
     ds = zarr.open((truth_path / crop_name / label).path, mode="r")
     voxel_size = ds.attrs["voxel_size"]
     if label in instance_classes:
-        # Penalize non-submission: every ground-truth instance is a false negative.
+        # Not submitted: each instance an FN at worst-case (0) boundary -- harsher than empty submission.
         truth_ids = unique(ds[:])
         n_instances = int(truth_ids[truth_ids != 0].size)
         return {
-            "f1": 0.0,
             "tp": 0,
             "fp": 0,
             "fn": n_instances,
-            "hausdorff_distance": compute_max_distance(voxel_size, ds.shape),
-            "normalized_hausdorff_distance": 0,
-            "combined_score": 0,
+            "hausdorff_norm_sum": 0.0,
+            "n_hausdorff": n_instances,
             "num_voxels": int(np.prod(ds.shape)),
             "voxel_size": voxel_size,
             "is_missing": True,

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -117,11 +117,12 @@ def score_instance(
         config: Evaluation configuration (uses defaults if None)
 
     Returns:
-        Dictionary containing all instance segmentation metrics
+        Dict with tp/fp/fn and per-instance Hausdorff sum/count. F1 and
+        combined_score are computed per class in aggregation, not here.
 
     Example:
         >>> scores = score_instance(pred, truth, voxel_size=(4.0, 4.0, 4.0))
-        >>> print(f"Combined score: {scores['combined_score']:.3f}")
+        >>> print(scores["tp"], scores["n_hausdorff"])
     """
     if config is None:
         config = EvaluationConfig.from_env()
@@ -145,16 +146,10 @@ def score_instance(
         mapping = match_instances(truth_label, pred_label, config)
     except (TooManyInstancesError, TooManyOverlapEdgesError) as e:
         logging.warning(f"Instance matching failed: {e}")
-        return _create_pathological_scores(
-            hausdorff_distance_max,
-            voxel_size,
-            "skipped_too_many_instances",
-        )
+        return _create_pathological_scores("skipped_too_many_instances")
     except MatchingFailedError as e:
         logging.error(f"Matching optimization failed: {e}")
-        return _create_pathological_scores(
-            hausdorff_distance_max, voxel_size, "matching_failed"
-        )
+        return _create_pathological_scores("matching_failed")
 
     # Remap predictions to match GT IDs
     if len(mapping) > 0 and not (len(mapping) == 1 and 0 in mapping):
@@ -170,49 +165,29 @@ def score_instance(
     # Free matching-stage scratch before the memory-heavy Hausdorff phase.
     gc.collect()
 
-    # Compute Hausdorff distances
+    # Per-instance Hausdorff distances (pooled per class in aggregation).
     hausdorff_distances = _compute_hausdorff_scores(
         mapping, truth_label, pred_label, n_pred, voxel_size, hausdorff_distance_max, truth_ids
     )
 
-    if len(hausdorff_distances) == 0:
-        hausdorff_distances = [hausdorff_distance_max]
-
-    # Compute F1 from instance matching counts
+    # F1 counts from matching (pooled per class in aggregation).
     gt_count = int(truth_ids.size)
-    matched_gt_ids = set(mapping.values()) - {0}
-    matched_pred_ids = set(mapping.keys()) - {0}
+    tp = len(set(mapping.values()) - {0})
+    fp = n_pred - len(set(mapping.keys()) - {0})
+    fn = gt_count - tp
 
-    tp = len(matched_gt_ids)
-    fp = n_pred - len(matched_pred_ids)
-    fn = gt_count - len(matched_gt_ids)
-    if gt_count == 0 and n_pred == 0:
-        # Correct true negative - 0/0, should be scored as 1.0
-        f1 = 1.0
-    else:
-        f1 = 2 * tp / (2 * tp + fp + fn)
-
-    # Aggregate scores
-    logging.info("Computing final scores...")
-    hausdorff_distances = np.asarray(hausdorff_distances, dtype=np.float64)
-    hausdorff_dist = float(hausdorff_distances.mean())
-    # Normalize vectorized: norm(voxel_size) is constant; inf distance -> 0.
-    vs_norm = np.linalg.norm(voxel_size)
-    normalized_hausdorff_dist = float((1.01 ** (-hausdorff_distances / vs_norm)).mean())
-    combined_score = (f1 * normalized_hausdorff_dist) ** 0.5
-    logging.info(f"F1: {f1:.4f} (TP={tp}, FP={fp}, FN={fn})")
-    logging.info(f"Hausdorff Distance: {hausdorff_dist:.4f}")
-    logging.info(f"Normalized Hausdorff Distance: {normalized_hausdorff_dist:.4f}")
-    logging.info(f"Combined Score: {combined_score:.4f}")
+    # Normalize per-instance distances; emit sum/count for per-class pooling.
+    norm = normalize_distance(hausdorff_distances, voxel_size)
+    hausdorff_norm_sum = float(np.sum(norm))
+    n_hausdorff = int(np.size(norm))
+    logging.info(f"TP={tp}, FP={fp}, FN={fn}, n_hausdorff={n_hausdorff}")
 
     return {
-        "f1": f1,
         "tp": tp,
         "fp": fp,
         "fn": fn,
-        "hausdorff_distance": hausdorff_dist,
-        "normalized_hausdorff_distance": normalized_hausdorff_dist,
-        "combined_score": combined_score,
+        "hausdorff_norm_sum": hausdorff_norm_sum,
+        "n_hausdorff": n_hausdorff,
         "status": "scored",
     }
 

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -65,8 +65,14 @@ def _compute_hausdorff_scores(
     voxel_size: tuple[float, ...],
     hausdorff_distance_max: float,
     truth_ids: np.ndarray | None = None,
-) -> list[float]:
-    """Compute Hausdorff distances for matched instances.
+) -> np.ndarray:
+    """Compute per-instance Hausdorff distances for pooling per class.
+
+    Produces one distance per ground-truth instance (matched -> real distance,
+    unmatched/FN -> max distance) plus a max-distance penalty per unmatched
+    prediction (hallucination). Returns an empty array when the crop has no
+    truth instances and no predictions, so empty crops contribute nothing to
+    the per-class pool.
 
     Args:
         mapping: Instance ID mapping (pred -> truth)
@@ -78,37 +84,24 @@ def _compute_hausdorff_scores(
         truth_ids: Precomputed non-zero ground-truth ids
 
     Returns:
-        List of Hausdorff distances
+        1D array of per-instance Hausdorff distances (possibly empty)
     """
-    if len(mapping) == 1 and 0 in mapping:
-        # Only background
-        return [0.0]
+    # One distance per truth instance (matched -> real, unmatched/FN -> max).
+    hausdorff_distances = optimized_hausdorff_distances(
+        truth_label, pred_label, voxel_size, hausdorff_distance_max, truth_ids=truth_ids
+    )
 
-    if len(mapping) > 0:
-        # Compute Hausdorff for matched instances
-        hausdorff_distances = optimized_hausdorff_distances(
-            truth_label, pred_label, voxel_size, hausdorff_distance_max, truth_ids=truth_ids
+    # Max-distance penalty per unmatched prediction (hallucination).
+    n_unmatched_pred = n_pred - len(set(mapping.keys()) - {0})
+    if n_unmatched_pred > 0:
+        hausdorff_distances = np.concatenate(
+            [
+                hausdorff_distances,
+                np.full(n_unmatched_pred, hausdorff_distance_max, dtype=np.float32),
+            ]
         )
 
-        # Add max distance for unmatched predictions
-        matched_pred_ids = set(mapping.keys()) - {0}
-        pred_ids = set(np.arange(1, n_pred + 1)) - {0}
-        unmatched_pred = pred_ids - matched_pred_ids
-
-        if len(unmatched_pred) > 0:
-            hausdorff_distances = np.concatenate(
-                [
-                    hausdorff_distances,
-                    np.full(
-                        len(unmatched_pred), hausdorff_distance_max, dtype=np.float32
-                    ),
-                ]
-            )
-
-        return hausdorff_distances.tolist()
-    else:
-        # No matches
-        return [hausdorff_distance_max]
+    return hausdorff_distances
 
 
 def score_instance(

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -180,7 +180,7 @@ def score_instance(
     norm = normalize_distance(hausdorff_distances, voxel_size)
     hausdorff_norm_sum = float(np.sum(norm))
     n_hausdorff = int(np.size(norm))
-    logging.info(f"TP={tp}, FP={fp}, FN={fn}, n_hausdorff={n_hausdorff}")
+    logging.debug(f"TP={tp}, FP={fp}, FN={fn}, n_hausdorff={n_hausdorff}")
 
     return {
         "tp": tp,
@@ -216,7 +216,7 @@ def score_semantic(pred_label, truth_label) -> dict[str, int | str]:
     fp = int(pred_label.sum()) - tp
     fn = int(truth_label.sum()) - tp
 
-    logging.info(f"Semantic counts: TP={tp}, FP={fp}, FN={fn}")
+    logging.debug(f"Semantic counts: TP={tp}, FP={fp}, FN={fn}")
 
     return {
         "tp": tp,

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/scoring.py
@@ -28,31 +28,24 @@ from .instance_matching import match_instances
 from .types import InstanceScoreDict
 
 
-def _create_pathological_scores(
-    hausdorff_distance_max: float,
-    voxel_size: tuple[float, ...],
-    status: str,
-) -> InstanceScoreDict:
-    """Create scores for pathological cases (matching failed).
+def _create_pathological_scores(status: str) -> InstanceScoreDict:
+    """Create scores for a crop whose instance matching failed.
+
+    The crop contributes nothing to the per-class pools (zero counts and no
+    Hausdorff entries), so a failure neither helps nor penalizes the class.
 
     Args:
-        hausdorff_distance_max: Maximum Hausdorff distance
-        voxel_size: Voxel size
-        status: Status string for the failure
+        status: Status string describing the failure.
 
     Returns:
-        Dictionary with worst-case scores
+        Score dict with zeroed counts and Hausdorff fields.
     """
     return {
-        "f1": 0.0,
         "tp": 0,
         "fp": 0,
         "fn": 0,
-        "hausdorff_distance": hausdorff_distance_max,
-        "normalized_hausdorff_distance": normalize_distance(
-            hausdorff_distance_max, voxel_size
-        ),
-        "combined_score": 0,
+        "hausdorff_norm_sum": 0.0,
+        "n_hausdorff": 0,
         "status": status,
     }
 

--- a/src/cellmap_segmentation_challenge/utils/eval_utils/types.py
+++ b/src/cellmap_segmentation_challenge/utils/eval_utils/types.py
@@ -10,7 +10,8 @@ class InstanceScoreDict(TypedDict, total=False):
     tp: int
     fp: int
     fn: int
-    hausdorff_distance: float
+    hausdorff_norm_sum: float
+    n_hausdorff: int
     normalized_hausdorff_distance: float
     combined_score: float
     num_voxels: int

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -501,11 +501,11 @@ def test_score_instance_f1_partial_match():
     scores = ev.score_instance(pred, truth, voxel_size=(1.0, 1.0))
 
     # tp=2 (GT 1 & 2 matched), fp=1 (pred 7 unmatched), fn=1 (GT 3 unmatched)
-    # f1 = 2*2 / (2*2 + 1 + 1) = 4/6 = 2/3
     assert scores["tp"] == 2
     assert scores["fp"] == 1
     assert scores["fn"] == 1
-    assert np.isclose(scores["f1"], 2 / 3)
+    # 3 truth instances + 1 unmatched prediction
+    assert scores["n_hausdorff"] == 4
 
 
 def test_score_instance_combined_score_formula():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -690,7 +690,9 @@ def test_empty_label_score_instance(tmp_path):
     # num_voxels should match volume size
     assert scores["num_voxels"] == arr.size
     assert scores["is_missing"] is True
-    assert scores["f1"] == 0.0
+    # empty truth -> no instances to miss
+    assert scores["fn"] == 0
+    assert scores["n_hausdorff"] == 0
 
 
 def test_missing_volume_score_mixed_labels(tmp_path):

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -823,8 +823,11 @@ def test_score_label_instance_integration(monkeypatch, tmp_path):
 
     assert crop_out == crop_name_str
     assert label_out == label_name
-    assert np.isclose(results["f1"], 1.0)
-    assert np.isclose(results["hausdorff_distance"], 0.0)
+    # single truth instance, matched -> tp=1, fn=0, one Hausdorff entry
+    assert results["status"] == "scored"
+    assert results["tp"] == 1
+    assert results["fn"] == 0
+    assert results["n_hausdorff"] == 1
     assert results["is_missing"] is False
 
 

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -817,6 +817,39 @@ def test_combine_scores_combined_pools_across_crops():
     assert np.isclose(ls["combined_score"], (f1 * hausdorff) ** 0.5)
 
 
+def test_public_scores_strips_crops_counts_and_unsubmitted_classes():
+    from cellmap_segmentation_challenge.utils.eval_utils.aggregation import (
+        public_scores,
+    )
+
+    scores = {
+        "crop1": {"mito": {"tp": 3}},  # per-crop entry
+        "label_scores": {
+            "mito": {"f1": 0.8, "combined_score": 0.77, "tp": 3, "fp": 1, "fn": 0},
+            "er": {"iou": 0.5, "tp": 10, "fp": 2, "fn": 4},  # not submitted
+        },
+        "overall_instance_score": 0.77,
+        "overall_semantic_score": 0.5,
+        "overall_score": 0.62,
+        "total_evals": 413,
+        "num_evals_done": 2,
+        "git_version": "abc",
+    }
+
+    public = public_scores(scores, submitted_labels={"mito"})
+
+    # per-crop entries dropped
+    assert "crop1" not in public
+    # only the submitted class is shown
+    assert set(public["label_scores"]) == {"mito"}
+    # raw counts stripped, ratio scores kept
+    assert public["label_scores"]["mito"] == {"f1": 0.8, "combined_score": 0.77}
+    # overalls and metadata preserved
+    assert public["overall_score"] == 0.62
+    assert public["total_evals"] == 413
+    assert public["git_version"] == "abc"
+
+
 # ------------------------
 # score_label & score_submission-style integration
 # ------------------------

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -737,10 +737,12 @@ def test_combine_scores_instance_and_semantic():
     scores = {
         "crop1": {
             "instance": {
-                "f1": 1.0,
-                "hausdorff_distance": 0.0,
-                "normalized_hausdorff_distance": 1.0,
-                "combined_score": 1.0,
+                # 2 matched instances at zero distance -> f1=1, hausdorff mean=1
+                "tp": 2,
+                "fp": 0,
+                "fn": 0,
+                "hausdorff_norm_sum": 2.0,
+                "n_hausdorff": 2,
                 "num_voxels": 8,
                 "voxel_size": (1.0, 1.0, 1.0),
                 "is_missing": False,

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -405,13 +405,12 @@ def test_score_instance_perfect_match():
     label = np.array([[0, 1, 1], [0, 2, 2]], dtype=np.int32)
     scores = ev.score_instance(label, label, voxel_size=(1.0, 1.0))
 
-    assert np.isclose(scores["f1"], 1.0)
     assert scores["tp"] == 2
     assert scores["fp"] == 0
     assert scores["fn"] == 0
-    assert np.isclose(scores["hausdorff_distance"], 0.0)
-    assert np.isclose(scores["normalized_hausdorff_distance"], 1.0)
-    assert np.isclose(scores["combined_score"], 1.0)
+    # both instances matched at zero distance -> normalized 1.0 each
+    assert scores["n_hausdorff"] == 2
+    assert np.isclose(scores["hausdorff_norm_sum"], 2.0)
 
 
 def test_score_instance_simple_shift():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -700,6 +700,8 @@ def test_missing_volume_score_mixed_labels(tmp_path):
 
     truth_root = tmp_path / "truth_volume.zarr"
     arr_inst = np.zeros((2, 2, 2), dtype=np.uint8)
+    arr_inst[0] = 1  # instance 1
+    arr_inst[1] = 2  # instance 2
     arr_sem = np.zeros((2, 2, 2), dtype=np.uint8)
 
     _create_simple_volume(truth_root, "crop1", "instance", arr_inst)
@@ -714,7 +716,9 @@ def test_missing_volume_score_mixed_labels(tmp_path):
     assert set(scores.keys()) == {"instance", "sem"}
     assert scores["instance"]["is_missing"] is True
     assert scores["sem"]["is_missing"] is True
-    assert scores["instance"]["f1"] == 0.0
+    # missing instance is penalized: each of the 2 truth instances is a FN
+    assert scores["instance"]["fn"] == 2
+    assert scores["instance"]["n_hausdorff"] == 2
     # missing semantic is penalized: empty truth -> fp=0, fn=all voxels -> IoU 0
     assert scores["sem"]["fp"] == 0
     assert scores["sem"]["fn"] == arr_sem.size

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -508,17 +508,6 @@ def test_score_instance_f1_partial_match():
     assert scores["n_hausdorff"] == 4
 
 
-def test_score_instance_combined_score_formula():
-    """Verify combined_score = sqrt(f1 * normalized_hausdorff)."""
-    from cellmap_segmentation_challenge import evaluate as ev
-
-    label = np.array([[0, 1, 1], [0, 2, 2]], dtype=np.int32)
-    scores = ev.score_instance(label, label, voxel_size=(1.0, 1.0))
-
-    expected = (scores["f1"] * scores["normalized_hausdorff_distance"]) ** 0.5
-    assert np.isclose(scores["combined_score"], expected)
-
-
 # ------------------------
 # score_semantic tests
 # ------------------------

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -776,6 +776,47 @@ def test_combine_scores_instance_and_semantic():
     assert np.isclose(combined["overall_semantic_score"], 0.5)
 
 
+def test_combine_scores_combined_pools_across_crops():
+    from cellmap_segmentation_challenge import evaluate as ev
+
+    # Same instance class in two crops -> counts and Hausdorff pooled per class.
+    scores = {
+        "crop1": {
+            "mito": {
+                "tp": 3,
+                "fp": 1,
+                "fn": 0,
+                "hausdorff_norm_sum": 2.4,
+                "n_hausdorff": 4,
+                "num_voxels": 8,
+                "voxel_size": (1.0, 1.0, 1.0),
+                "is_missing": False,
+            }
+        },
+        "crop2": {
+            "mito": {
+                "tp": 1,
+                "fp": 0,
+                "fn": 2,
+                "hausdorff_norm_sum": 1.0,
+                "n_hausdorff": 2,
+                "num_voxels": 8,
+                "voxel_size": (1.0, 1.0, 1.0),
+                "is_missing": False,
+            }
+        },
+    }
+
+    combined = ev.combine_scores(scores, include_missing=True, instance_classes=["mito"])
+    ls = combined["label_scores"]["mito"]
+
+    f1 = 8 / 11  # 2*tp / (2*tp + fp + fn), pooled tp=4 fp=1 fn=2
+    hausdorff = 3.4 / 6  # pooled sum / count
+    assert np.isclose(ls["f1"], f1)
+    assert np.isclose(ls["normalized_hausdorff_distance"], hausdorff)
+    assert np.isclose(ls["combined_score"], (f1 * hausdorff) ** 0.5)
+
+
 # ------------------------
 # score_label & score_submission-style integration
 # ------------------------

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -423,13 +423,13 @@ def test_score_instance_simple_shift():
     voxel_size = (1.0, 1.0)
     scores = ev.score_instance(pred, truth, voxel_size)
 
-    # F1 should be 1.0 since the single instance is matched
-    assert np.isclose(scores["f1"], 1.0)
     assert scores["tp"] == 1
     assert scores["fp"] == 0
     assert scores["fn"] == 0
-    # Hausdorff distance is 1 (each point moves 1 voxel)
-    assert np.isclose(scores["hausdorff_distance"], 1.0)
+    # one matched instance, Hausdorff distance 1 -> normalized 1.01**(-1/||vs||)
+    assert scores["n_hausdorff"] == 1
+    expected = 1.01 ** (-1.0 / np.linalg.norm(voxel_size))
+    assert np.isclose(scores["hausdorff_norm_sum"], expected)
 
 
 def test_score_instance_f1_all_fp():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -433,7 +433,7 @@ def test_score_instance_simple_shift():
 
 
 def test_score_instance_f1_all_fp():
-    """Prediction has instances but GT has none -> f1 = 0."""
+    """Prediction has instances but GT has none -> all false positives."""
     from cellmap_segmentation_challenge import evaluate as ev
 
     truth = np.zeros((4, 4), dtype=np.int32)
@@ -442,10 +442,11 @@ def test_score_instance_f1_all_fp():
     )
     scores = ev.score_instance(pred, truth, voxel_size=(1.0, 1.0))
 
-    assert np.isclose(scores["f1"], 0.0)
     assert scores["tp"] == 0
     assert scores["fn"] == 0
     assert scores["fp"] == 2
+    # 2 hallucinated predictions, each a max-distance penalty
+    assert scores["n_hausdorff"] == 2
 
 
 def test_score_instance_f1_all_fn():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -450,7 +450,7 @@ def test_score_instance_f1_all_fp():
 
 
 def test_score_instance_f1_all_fn():
-    """GT has instances but prediction has none -> f1 = 0."""
+    """GT has instances but prediction has none -> all false negatives."""
     from cellmap_segmentation_challenge import evaluate as ev
 
     truth = np.array(
@@ -459,10 +459,11 @@ def test_score_instance_f1_all_fn():
     pred = np.zeros((4, 4), dtype=np.int32)
     scores = ev.score_instance(pred, truth, voxel_size=(1.0, 1.0))
 
-    assert np.isclose(scores["f1"], 0.0)
     assert scores["tp"] == 0
     assert scores["fp"] == 0
     assert scores["fn"] == 2
+    # 2 missed truth instances, each a max-distance penalty
+    assert scores["n_hausdorff"] == 2
 
 
 def test_score_instance_empty_vs_empty_true_negative():

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -466,8 +466,8 @@ def test_score_instance_f1_all_fn():
     assert scores["n_hausdorff"] == 2
 
 
-def test_score_instance_empty_vs_empty_true_negative():
-    """Neither GT nor prediction has instances -> correct true negative, score 1.0."""
+def test_score_instance_empty_vs_empty_contributes_nothing():
+    """Neither GT nor prediction has instances -> no counts, nothing pooled."""
     from cellmap_segmentation_challenge import evaluate as ev
 
     truth = np.zeros((4, 4), dtype=np.int32)
@@ -477,10 +477,9 @@ def test_score_instance_empty_vs_empty_true_negative():
     assert scores["tp"] == 0
     assert scores["fp"] == 0
     assert scores["fn"] == 0
-    # Correctly predicting absence is perfect, 0/0 -> 1.0
-    assert np.isclose(scores["f1"], 1.0)
-    assert np.isclose(scores["normalized_hausdorff_distance"], 1.0)
-    assert np.isclose(scores["combined_score"], 1.0)
+    # empty crop contributes nothing to the per-class pools (no inflation)
+    assert scores["n_hausdorff"] == 0
+    assert scores["hausdorff_norm_sum"] == 0.0
 
 
 def test_score_instance_f1_partial_match():

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -264,22 +264,18 @@ class TestScoreInstanceHelpers:
         assert scores["n_hausdorff"] == 0
         assert scores["status"] == "test_failure"
 
-    def test_compute_hausdorff_scores_only_background(self):
-        """Test Hausdorff score computation with only background."""
-        mapping = {0: 0}
-        truth = np.zeros((10, 10))
-        pred = np.zeros((10, 10))
-
+    def test_compute_hausdorff_scores_empty(self):
+        """No truth and no predictions -> empty (contributes nothing)."""
         distances = _compute_hausdorff_scores(
-            mapping,
-            truth,
-            pred,
+            {0: 0},
+            np.zeros((10, 10)),
+            np.zeros((10, 10)),
             n_pred=0,
             voxel_size=(4.0, 4.0),
             hausdorff_distance_max=100.0,
         )
 
-        assert distances == [pytest.approx(0.0)]
+        assert len(distances) == 0
 
     def test_compute_hausdorff_scores_no_mapping(self):
         """Test Hausdorff score computation with no mapping."""

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -255,16 +255,13 @@ class TestScoreInstanceHelpers:
     """Test helper functions for score_instance."""
 
     def test_create_pathological_scores(self):
-        """Test creation of pathological scores."""
-        scores = _create_pathological_scores(
-            hausdorff_distance_max=100.0,
-            voxel_size=(4.0, 4.0, 4.0),
-            status="test_failure",
-        )
+        """Matching-failure scores contribute nothing to the pools."""
+        scores = _create_pathological_scores(status="test_failure")
 
-        assert scores["f1"] == 0.0
-        assert scores["combined_score"] == 0
-        assert scores["hausdorff_distance"] == 100.0
+        assert scores["tp"] == 0
+        assert scores["fp"] == 0
+        assert scores["fn"] == 0
+        assert scores["n_hausdorff"] == 0
         assert scores["status"] == "test_failure"
 
     def test_compute_hausdorff_scores_only_background(self):

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -277,22 +277,19 @@ class TestScoreInstanceHelpers:
 
         assert len(distances) == 0
 
-    def test_compute_hausdorff_scores_no_mapping(self):
-        """Test Hausdorff score computation with no mapping."""
-        mapping = {}
-        truth = np.zeros((10, 10))
-        pred = np.zeros((10, 10))
-
+    def test_compute_hausdorff_scores_unmatched_predictions(self):
+        """Hallucinations (unmatched predictions) each get the max penalty."""
         distances = _compute_hausdorff_scores(
-            mapping,
-            truth,
-            pred,
+            {},
+            np.zeros((10, 10)),
+            np.zeros((10, 10)),
             n_pred=5,
             voxel_size=(4.0, 4.0),
             hausdorff_distance_max=100.0,
         )
 
-        assert distances == [100.0]
+        assert len(distances) == 5
+        assert np.allclose(distances, 100.0)
 
 
 # ============================================================================

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -560,8 +560,8 @@ class TestRefactoredIntegration:
         config = EvaluationConfig()
         scores = score_instance(pred, truth, voxel_size, config=config)
 
-        assert "f1" in scores
-        assert "combined_score" in scores
+        assert "tp" in scores
+        assert "n_hausdorff" in scores
         assert scores["status"] == "scored"
 
     def test_score_instance_handles_too_many_instances(self):

--- a/tests/test_evaluate_refactored.py
+++ b/tests/test_evaluate_refactored.py
@@ -575,8 +575,8 @@ class TestRefactoredIntegration:
         scores = score_instance(pred, truth, voxel_size, config=config)
 
         assert scores["status"] == "skipped_too_many_instances"
-        assert scores["f1"] == 0.0
-        assert scores["combined_score"] == 0
+        assert scores["tp"] == 0
+        assert scores["n_hausdorff"] == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Builds on PR #210. Reworks instance scoring to emit per-instance Hausdorff
sum/count (instead of preaggregated values), computes per-class combined scores
from pooled Hausdorff, and splits results output into a public aggregate file
and a full `_extended` sibling.

## Changes

**Scoring**
- `score_instance` emits per-instance Hausdorff sum/count
- `_compute_hausdorff_scores` returns a per-instance array
- `_create_pathological_scores` takes only `status`
- `empty_label_score` penalizes non-submission (worst-case boundary)

**Distance**
- `vectorize normalize_distance` (scalar or array)
- Clamp ROI pad to volume extent (fixes inf-cast warning)

**Aggregation / output**
- Per-class combined score from pooled Hausdorff; plain-mean overalls
- Write public aggregate-only results to `result_file`
- Write full results to an `_extended` sibling file

**Types**
- `InstanceScoreDict` uses `hausdorff_norm_sum`/`n_hausdorff`

**Tests**
- Cover public-scores filtering and combined-score pooling across crops
- Instance/Hausdorff scoring tests updated to `tp`/`fn`/`n_hausdorff`

## Notes

Stacked on PR #210
